### PR TITLE
Feature fix mc hex digest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,9 +169,9 @@ k.server = function Server(con) {
     }
   }
 
-  r.mcHexDigest = function mcHexDigest(buf, encoding) {
-    if (!(buf instanceof Buffer))
-      buf = new Buffer(buf, encoding);
+  r.mcHexDigest = function mcHexDigest(hash, encoding) {
+    if (!(hash instanceof Buffer))
+      hash = new Buffer(hash, encoding);
     // check for negative hashes
     var negative = hash.readInt8(0) < 0;
     if (negative) performTwosCompliment(hash);

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,8 +169,9 @@ k.server = function Server(con) {
     }
   }
 
-  r.mcHexDigest = function mcHexDigest(str) {
-    var hash = new Buffer(crypto.createHash('sha1').update(str).digest(), 'binary');
+  r.mcHexDigest = function mcHexDigest(buf, encoding) {
+    if (!(buf instanceof Buffer))
+      buf = new Buffer(buf, encoding);
     // check for negative hashes
     var negative = hash.readInt8(0) < 0;
     if (negative) performTwosCompliment(hash);
@@ -186,7 +187,7 @@ k.server = function Server(con) {
     r._call('session/minecraft/join', {
       "accessToken": token,
       "selectedProfile": profile,
-      "serverId": r.mcHexDigest(serverid + sharedsecret + serverkey)
+      "serverId": r.mcHexDigest(crypto.createHash('sha1').update(serverid).update(sharedsecret).update(serverkey).digest())
     }, function(err, data) {
       cb(err, data);
     });


### PR DESCRIPTION
This allows passing the different components of the hash as buffers (note that passing as strings still works)