### PR TITLE
Add response body to refresh callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ var k = function Yggdrasil (con) {
    * Refreshes a accessToken.
    * @param  {String}   access Old Access Token
    * @param  {String}   client Client Token
-   * @param  {Function} cb     (err, new token)
+   * @param  {Function} cb     (err, new token, full response body)
    */
   r.refresh = function (access, client, cb) {
     r._call('refresh', {
@@ -75,7 +75,7 @@ var k = function Yggdrasil (con) {
       if (data.clientToken !== client) {
         cb("clientToken assertion failed");
       } else {
-        cb(null, data.accessToken);
+        cb(null, data.accessToken, data);
       }
     });
   };


### PR DESCRIPTION
Allows accessing the rest of the data mojang sends our way when refreshing a token