### PR TITLE
When hasJoined fails, it doesn't give any output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -198,13 +198,12 @@ k.server = function Server(con) {
       method: 'GET',
       uri: config.host + '/session/minecraft/hasJoined?username='+username+'&serverId='+hash
     }, function (err, resp, body) {
-      if (body && body.error) {
-        var out = body.errorMessage;
-        out.status = resp.statusCode;
-        cb(out);
-      } else {
+      if (err) // Error
         cb(err, body);
-      }
+      else if (body.hasOwnProperty("id")) // Success
+        cb(err, body);
+      else
+        cb(new Error("Failed to verify username!"));
     });
   };
 


### PR DESCRIPTION
hasJoined is a bit of an oddball in mojang's api : instead of failing with a 40* statusCode and an error in the body, it simply returns no content.