### PR TITLE
Fix hex digest crashing on some bytes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ function performTwosCompliment (buffer) {
     newByte = ~value & 0xff
     if (carry) {
       carry = newByte === 0xff
-      buffer.writeUInt8(newByte + 1, i)
+      buffer.writeUInt8(carry ? 0 : (newByte + 1), i)
     } else {
       buffer.writeUInt8(newByte, i)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -50,12 +50,17 @@ describe('utils', function () {
       var testdata = {
         'Notch': '4ed1f46bbe04bc756bcb17c0c7ce3e4632f06a48',
         'jeb_': '-7c9d5b0044c130109a5d7b5fb5c317c02b4e28c1',
-        'simon': '88e16a1019277b15d58faf0541e11910eb756f6'
+        'simon': '88e16a1019277b15d58faf0541e11910eb756f6',
+        'dummy697': '-aa2358520428804697026992cf6035d7f096a00' // triggers 2's complement bug
       }
       Object.keys(testdata).forEach(function (name) {
         var hash = crypto.createHash('sha1').update(name).digest()
         utils.mcHexDigest(hash).should.equal(testdata[name])
       })
+    })
+
+    it('should handle negative hashes ending with a zero byte without crashing', function () {
+      utils.mcHexDigest(Buffer([-1, 0])).should.equal('-100')
     })
   })
 })


### PR DESCRIPTION
I got 'lucky' and had a login process crash with a strange error
reported by Node's Buffer class: `TypeError: "value" argument is out of bounds`.

Turns out there is an edge case in `performTwosCompliment` that was
not handled and it ended up trying to write `256` as a byte into a
buffer.

The bug is not easily reproduced since the digests that are processed are
random and it takes a specific arrangement of bytes in the SHA-1 output
to trigger it. But through an automated search I found a string that
triggers the behavior and added it to the test cases.