### PR TITLE
Client refresh callback is called twice on error

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -47,7 +47,6 @@ Client.refresh = function (access, client, cb) {
     accessToken: access,
     clientToken: client
   }, function (err, data) {
-    if (err) cb(err)
     if (data && data.clientToken !== client) {
       cb(new Error('clientToken assertion failed'))
     } else {


### PR DESCRIPTION
If the refresh function encounters an error (not due to clientToken assertion), it runs the callback twice. This caused my mocha (for another module that depends on yours) to fail.

I removed this first callback as it is redundant, as the callback in the else will return errors if they exist and null if they don't.